### PR TITLE
Fix blueprint mirroring 

### DIFF
--- a/Mods/BlueprintTweaks/src/BlueprintTweaks/MirrorBlueprints/BlueprintUtilsPatch2.cs
+++ b/Mods/BlueprintTweaks/src/BlueprintTweaks/MirrorBlueprints/BlueprintUtilsPatch2.cs
@@ -226,6 +226,34 @@ namespace BlueprintTweaks
                 .InsertAndAdvance(new CodeInstruction(OpCodes.Ldloc_S, 30)) //TODO this is unsafe
                 .InsertAndAdvance(Transpilers.EmitDelegate<Func<float, BlueprintBuilding, float>>(MirrorBuildingRotation));
 
+            // STEP 3b - Inserter
+
+            // turns
+            // lrot = Maths.SphericalRotation(dir, 0f) * Quaternion.Euler(blueprintBuilding.pitch, blueprintBuilding.yaw - (float)num * 90f, blueprintBuilding.tilt);
+
+            // into
+            // lrot = Maths.SphericalRotation(dir, 0f) * Quaternion.Euler(blueprintBuilding.pitch, MirrorBuildingRotation(blueprintBuilding.yaw, blueprintBuilding) - (float)num * 90f, blueprintBuilding.tilt);
+
+            matcher.MatchForward(false,
+                new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(BlueprintBuilding), nameof(BlueprintBuilding.yaw)))
+            ).Advance(1)
+            .InsertAndAdvance(new CodeInstruction(OpCodes.Ldloc_S, 30)) //TODO this is unsafe
+            .InsertAndAdvance(Transpilers.EmitDelegate<Func<float, BlueprintBuilding, float>>(MirrorBuildingRotation)).Advance(2);
+
+            // STEP 4b - Inserter
+
+            // turns 							
+            // lrot2 = Maths.SphericalRotation(dir2, 0f) * Quaternion.Euler(blueprintBuilding.pitch2, blueprintBuilding.yaw2 - (float)num * 90f, blueprintBuilding.tilt2);
+
+            // into
+            // lrot2 = Maths.SphericalRotation(dir2, 0f) * Quaternion.Euler(blueprintBuilding.pitch2, MirrorBuildingRotation(blueprintBuilding.yaw2, blueprintBuilding) - (float)num * 90f, blueprintBuilding.tilt2);
+
+            matcher.MatchForward(false,
+                new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(BlueprintBuilding), nameof(BlueprintBuilding.yaw2)))
+            ).Advance(1)
+            .InsertAndAdvance(new CodeInstruction(OpCodes.Ldloc_S, 30)) //TODO this is unsafe
+            .InsertAndAdvance(Transpilers.EmitDelegate<Func<float, BlueprintBuilding, float>>(MirrorBuildingRotation));
+
             // STEP 5
 
             matcher.MatchForward(false,


### PR DESCRIPTION
This fixes https://github.com/limoka/DSP-Mods/issues/115.

Before the devs implemented patch/tilt for belts, all buildings used the same logic to update rotations:

```csharp
Quaternion lrot = Maths.SphericalRotation(dir, blueprintBuilding.yaw - (float)num * 90f);
Quaternion lrot2 = Maths.SphericalRotation(dir2, blueprintBuilding.yaw2 - (float)num * 90f);
```

When the devs implement belt pitch/tilt, they added some logic to handle inserter rotations differently:

```csharp
if (buildPreview.desc.isInserter) {
	lrot = Maths.SphericalRotation(dir, 0f) * Quaternion.Euler(blueprintBuilding.pitch, blueprintBuilding.yaw - (float)num * 90f, blueprintBuilding.tilt);
	lrot2 = Maths.SphericalRotation(dir2, 0f) * Quaternion.Euler(blueprintBuilding.pitch2, blueprintBuilding.yaw2 - (float)num * 90f, blueprintBuilding.tilt2);
}
```

This additional code wasn't handled by the transpiler.

The fix is simple: just repeat the yaw and yaw2 patch again to account for this new logic.

I've tested this on my local game on both simple and complex blueprints.  